### PR TITLE
Add file sensor and use it for cache busting

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ Everything is designed for persistent memory, offline-first operation, and conti
     * Place generated images in `/srv/homeassistant/www/daily_images/`
     * Place generated text in `/srv/homeassistant/ai/`
     * Reference these in your `dashboard.yaml` (e.g., `image: "/local/daily_images/fact.png?v=..."`)
+    * Create a file sensor so dashboards refresh when `current_timestamp.txt` changes. Example:
+
+      ```yaml
+      # examples/brain_boost_timestamp_sensor.yaml
+      sensor:
+        - platform: file
+          name: Brain Boost Timestamp
+          file_path: /srv/homeassistant/www/daily_images/current_timestamp.txt
+          value_template: "{{ value }}"
+      ```
+
+      Then use `cachebust={{ states('sensor.brain_boost_timestamp') }}` in `dashboard.yaml`.
 
 ---
 

--- a/dashboard.yaml
+++ b/dashboard.yaml
@@ -95,8 +95,7 @@ views:
                     cards:
                       - type: picture
                         image: >-
-                          /local/daily_images/fact.png?cachebust={{ range(1,
-                          999999) | random }}
+                          /local/daily_images/fact.png?cachebust={{ states('sensor.brain_boost_timestamp') }}
                         card_mod:
                           style: |
                             ha-card {
@@ -123,8 +122,7 @@ views:
                     cards:
                       - type: picture
                         image: >-
-                          /local/daily_images/on_this_day.png?cachebust={{
-                          range(1, 999999) | random }}
+                          /local/daily_images/on_this_day.png?cachebust={{ states('sensor.brain_boost_timestamp') }}
                         card_mod:
                           style: |
                             ha-card {
@@ -151,8 +149,7 @@ views:
                     cards:
                       - type: picture
                         image: >-
-                          /local/daily_images/quote.png?cachebust={{ range(1,
-                          999999) | random }}
+                          /local/daily_images/quote.png?cachebust={{ states('sensor.brain_boost_timestamp') }}
                         card_mod:
                           style: |
                             ha-card {
@@ -179,8 +176,7 @@ views:
                     cards:
                       - type: picture
                         image: >-
-                          /local/daily_images/poem.png?cachebust={{ range(1,
-                          999999) | random }}
+                          /local/daily_images/poem.png?cachebust={{ states('sensor.brain_boost_timestamp') }}
                         card_mod:
                           style: |
                             ha-card {
@@ -207,8 +203,7 @@ views:
                     cards:
                       - type: picture
                         image: >-
-                          /local/daily_images/history.png?cachebust={{ range(1,
-                          999999) | random }}
+                          /local/daily_images/history.png?cachebust={{ states('sensor.brain_boost_timestamp') }}
                         card_mod:
                           style: |
                             ha-card {
@@ -235,8 +230,7 @@ views:
                     cards:
                       - type: picture
                         image: >-
-                          /local/daily_images/word.png?cachebust={{ range(1,
-                          999999) | random }}
+                          /local/daily_images/word.png?cachebust={{ states('sensor.brain_boost_timestamp') }}
                         card_mod:
                           style: |
                             ha-card {
@@ -263,8 +257,7 @@ views:
                     cards:
                       - type: picture
                         image: >-
-                          /local/daily_images/riddle.png?cachebust={{ range(1,
-                          999999) | random }}
+                          /local/daily_images/riddle.png?cachebust={{ states('sensor.brain_boost_timestamp') }}
                         card_mod:
                           style: |
                             ha-card {
@@ -291,8 +284,7 @@ views:
                     cards:
                       - type: picture
                         image: >-
-                          /local/daily_images/joke.png?cachebust={{ range(1,
-                          999999) | random }}
+                          /local/daily_images/joke.png?cachebust={{ states('sensor.brain_boost_timestamp') }}
                         card_mod:
                           style: |
                             ha-card {

--- a/examples/brain_boost_timestamp_sensor.yaml
+++ b/examples/brain_boost_timestamp_sensor.yaml
@@ -1,0 +1,7 @@
+# Sample Home Assistant sensor to update dashboard images
+sensor:
+  - platform: file
+    name: Brain Boost Timestamp
+    file_path: /srv/homeassistant/www/daily_images/current_timestamp.txt
+    value_template: "{{ value }}"
+    scan_interval: 30


### PR DESCRIPTION
## Summary
- read timestamp from `/srv/homeassistant/www/daily_images/current_timestamp.txt`
- update `dashboard.yaml` to use `sensor.brain_boost_timestamp` instead of random numbers
- document the new sensor in `README.md`
- provide example config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845dc45803c832da1956ceb397a311a