### PR TITLE
Use HA_TOKEN env var in add_event script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 OPENAI_API_KEY=sk-your-key-here
 
 # Future configuration (not yet needed)
-# HA_API_TOKEN=your-home-assistant-token
+# HA_TOKEN=your-home-assistant-token
 # HA_URL=http://homeassistant.local:8123
 # MISTRAL_MODEL_PATH=/path/to/mistral-7b-instruct-v0.1.Q4_K_M.gguf
 # KIWIX_DATA_PATH=/media/pi/data/kiwix

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Security - NEVER commit these
+# Ignore .env files anywhere in the repository
 .env
+**/.env
 *.key
 *.pem
 secrets.yaml

--- a/README.md
+++ b/README.md
@@ -76,7 +76,11 @@ Everything is designed for persistent memory, offline-first operation, and conti
     ```bash
     cp .env.example .env
     # Edit .env and add your OpenAI API key
+    # Optional: add HA_TOKEN for Home Assistant scripts
     ```
+
+    The `add_event.sh` helper script will read `HA_TOKEN` from this file
+    or your environment when adding calendar entries.
 
 4.  **Run the script:**
     ```bash

--- a/add_event.sh
+++ b/add_event.sh
@@ -1,5 +1,22 @@
 #!/bin/bash
-TOKEN="Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhZjAwN2ZhMWJiMjI0NGQwYTYxZDE1MTUwN2FlZTU0YyIsImlhdCI6MTc0ODg4ODI1NCwiZXhwIjoyMDY0MjQ4MjU0fQ.Yaz5G0PSNW868ehaXZkzRSXJGGzYPvlK2lNWL4ERqM4"
+# Add a calendar event via the Home Assistant API.
+# Usage: ./add_event.sh "2024-06-01T13:00:00" "2024-06-01T14:00:00" "Meeting"
+#
+# The script expects HA_TOKEN to contain your long-lived access token.
+# It will source a local .env if present.
+# The Authorization header is constructed as "Bearer $HA_TOKEN".
+if [ -f ".env" ]; then
+    set -a
+    source ".env"
+    set +a
+fi
+
+if [ -z "$HA_TOKEN" ]; then
+    echo "HA_TOKEN not set. Export it or place it in .env" >&2
+    exit 1
+fi
+
+TOKEN="$HA_TOKEN"
 HA_IP="192.168.1.211"
 ENTITY="calendar.james_a_cockburn_gmail_com"
 
@@ -18,6 +35,6 @@ EOF
 )
 
 curl -s -X POST "http://$HA_IP:8123/api/services/calendar/create_event" \
-     -H "Authorization: $TOKEN" \
+     -H "Authorization: Bearer $TOKEN" \
      -H "Content-Type: application/json" \
      -d "$DATA"


### PR DESCRIPTION
## Summary
- load HA token from `.env` if present
- ignore nested `.env` files
- document HA_TOKEN in example env file and README

## Testing
- `pytest -q`
- `bash -n add_event.sh`


------
https://chatgpt.com/codex/tasks/task_e_6845dc60e818832da38fd34dd7d8ad9c