### PR TITLE
Add status code check for image downloads

### DIFF
--- a/daily_brain_boost_complete.py
+++ b/daily_brain_boost_complete.py
@@ -231,7 +231,13 @@ def gpt_image(prompt, filename):
         )
         
         image_url = response.data[0].url
-        image_data = requests.get(image_url, timeout=30).content
+        response_get = requests.get(image_url, timeout=30)
+        if response_get.status_code != 200:
+            log.error(
+                f"Image download failed for {filename} with status {response_get.status_code}"
+            )
+            return False
+        image_data = response_get.content
         
         # Save with timestamp in filename
         base_name = filename.replace('.png', '')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ openai==1.35.3
 python-dotenv==1.0.0
 requests==2.31.0
 pillow==10.3.0
+pytest==8.2.0
 
 # Future modules (not yet required)
 # pyaudio==0.2.13

--- a/tests/test_gpt_image.py
+++ b/tests/test_gpt_image.py
@@ -1,0 +1,68 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _setup_module(monkeypatch, tmp_path):
+    root = Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+
+    class DummyChatCompletions:
+        def create(self, *args, **kwargs):
+            return types.SimpleNamespace(
+                choices=[types.SimpleNamespace(message=types.SimpleNamespace(content="Monet"))]
+            )
+
+    class DummyImages:
+        def generate(self, *args, **kwargs):
+            return types.SimpleNamespace(
+                data=[types.SimpleNamespace(url="http://example.com/img.png")]
+            )
+
+    class DummyOpenAI:
+        def __init__(self, *args, **kwargs):
+            self.chat = types.SimpleNamespace(completions=DummyChatCompletions())
+            self.images = DummyImages()
+
+    monkeypatch.setattr('openai.OpenAI', DummyOpenAI)
+
+    module = importlib.import_module('daily_brain_boost_complete')
+    monkeypatch.setattr(module, 'OUTDIR', tmp_path)
+    monkeypatch.setattr(module, 'WWW_DIR', tmp_path)
+    (tmp_path / "images").mkdir(exist_ok=True)
+    tmp_path.mkdir(exist_ok=True)
+
+    return module
+
+
+def test_gpt_image_download_success(monkeypatch, tmp_path):
+    module = _setup_module(monkeypatch, tmp_path)
+
+    class DummyResponse:
+        def __init__(self):
+            self.status_code = 200
+            self.content = b'data'
+
+    monkeypatch.setattr(module.requests, 'get', lambda *a, **k: DummyResponse())
+
+    assert module.gpt_image('test prompt', 'test.png') is True
+    assert any(tmp_path.glob('test_*'))
+
+
+def test_gpt_image_download_failure(monkeypatch, tmp_path):
+    module = _setup_module(monkeypatch, tmp_path)
+
+    class DummyResponse:
+        def __init__(self):
+            self.status_code = 404
+            self.content = b''
+
+    monkeypatch.setattr(module.requests, 'get', lambda *a, **k: DummyResponse())
+
+    assert module.gpt_image('test prompt', 'fail.png') is False
+    assert not any(tmp_path.glob('fail_*'))


### PR DESCRIPTION
## Summary
- handle HTTP errors when downloading generated images
- include pytest for testing
- add unit tests for image download success and failure cases

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845dd50c460832dadf293c7796f31e1