### PR TITLE
Improve gpt_image error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ See `docs/PI_SETUP.md` for full hardware, Docker, directory, and environment det
     * (Re)activate `venv`, re-run `pip install -r requirements.txt`
 * **.env not found?**
     * Check permissions and location in `/media/pi/data/assistant/`
+* **Image errors?**
+    * Inspect `brain_boost.log` for `WARNING` lines about failed image generation
+    * `grep 'Image generation failed' /media/pi/data/assistant/brain_boost.log`
 * **Still stuck?**
     * See `docs/` or open an issue
 

--- a/daily_brain_boost_complete.py
+++ b/daily_brain_boost_complete.py
@@ -35,6 +35,7 @@ TODAY_STR = datetime.now().strftime("%Y%m%d")
 TIMESTAMP = str(int(time.time()))  # Unique timestamp for this run
 
 # --- LOGGING ---
+LOGFILE.parent.mkdir(parents=True, exist_ok=True)
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s %(levelname)s %(message)s",
@@ -270,7 +271,9 @@ def gpt_image(prompt, filename):
         return True
         
     except Exception as e:
-        log.error(f"Image generation failed for {filename}: {e}")
+        log.exception(
+            "Image generation failed for %s. Prompt: %s", filename, prompt
+        )
         return False
 
 def fetch_joke():
@@ -371,7 +374,11 @@ def main():
             if content and "[GENERATION FAILED]" not in content:
                 image_name = filename.replace('.txt', '.png')
                 if filename != "word.txt":  # Word already handled
-                    gpt_image(content, image_name)
+                    success = gpt_image(content, image_name)
+                    if success is False:
+                        log.warning(
+                            f"Image generation failed for {image_name}" 
+                        )
     
     # Update history
     for filename, content in generated_content.items():


### PR DESCRIPTION
## Summary
- log exception and prompt in `gpt_image`
- detect failed image generation in `main()` and warn
- ensure logging directory exists
- document checking the log for image errors

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e54d2074832d95a48ddb15a199b4