### PR TITLE
Switch recipe finder to GPT and dedicated dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Everything is designed for persistent memory, offline-first operation, and conti
 - **Budget Agent**: Designed, not implemented
 - **3D Print Automation**: Infrastructure in progress
 - **Document OCR**: Scripts and pipeline designed
+- **Recipe Suggestions Page**: GPT-based recipe ideas and selection
 
 ---
 
@@ -50,6 +51,7 @@ Everything is designed for persistent memory, offline-first operation, and conti
 ├── voice/                           # Voice assistant scripts
 ├── llm/                             # Local LLM configs
 ├── calendar/                        # Calendar integration
+├── recipes/                         # Recipe finder module
 ├── ai/                              # (Text output, ignored by git)
 ├── venv/                            # Python virtualenv, not tracked
 └── ... (other modules)
@@ -132,6 +134,7 @@ Everything is designed for persistent memory, offline-first operation, and conti
 | Calendar Integration   | ✅ Working | Voice add planned                      |
 | Knowledge Base (RAG)   | 🟡 Partial | Kiwix server running                   |
 | Budget Agent           | 🟡 Designed | Not yet implemented                    |
+| Recipe Suggestions     | 🆕 Experimental | GPT-based suggestions dashboard  |
 | 3D Print Automation    | 🟡 Planned | Infrastructure set                     |
 | OCR Pipeline           | 🟡 Designed | Scripts drafted                        |
 
@@ -254,7 +257,7 @@ Personal/family/educational use only.
 Contact owner for commercial or multi-user licensing.
 
 ---
-*Last updated: 2025-06-08*
+*Last updated: 2025-06-09*
 *Maintainer: James Cockburn*
 
 **Building the future of home intelligence, one module at a time.**

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -1,0 +1,17 @@
+# Recipe Finder Module
+
+This module uses GPT to generate recipe ideas from a list of ingredients
+and saves the chosen recipe for display on a dedicated Home Assistant dashboard.
+
+## Usage
+
+1. Set `OPENAI_API_KEY` in your environment or `.env` file.
+2. Run the script with a comma-separated list of ingredients:
+
+```bash
+python recipes/recipe_finder.py "tomato, cheese"
+```
+
+The script lists up to three recipe options and prompts you to choose one.
+The selected title is written to `/srv/homeassistant/ai/selected_recipe.txt`.
+You can display this file via a file sensor or markdown card in Home Assistant.

--- a/recipes/recipe_finder.py
+++ b/recipes/recipe_finder.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Recipe Finder for Home Assistant.
+
+Uses GPT to suggest recipe ideas based on a comma-separated list of
+ingredients. Presents up to three options and saves the chosen
+recipe title for display on a dashboard.
+
+Usage:
+    python recipe_finder.py "chicken, rice, tomato"
+
+Environment variables:
+    OPENAI_API_KEY - API key for the OpenAI client
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import List
+
+from openai import OpenAI
+
+TEXT_MODEL = "gpt-4o"
+OUTPUT_DIR = Path("/srv/homeassistant/ai")
+OPTIONS_FILE = OUTPUT_DIR / "recipe_options.txt"
+SELECTED_FILE = OUTPUT_DIR / "selected_recipe.txt"
+
+
+def fetch_recipes(ingredients: str, limit: int = 3) -> List[str]:
+    """Return recipe titles suggested by GPT for the given ingredients."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise EnvironmentError("OPENAI_API_KEY must be set")
+
+    client = OpenAI(api_key=api_key)
+    prompt = (
+        f"Suggest {limit} recipes using these ingredients: {ingredients}. "
+        "Reply with a simple numbered list of titles only."
+    )
+    try:
+        response = client.chat.completions.create(
+            model=TEXT_MODEL,
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=200,
+            temperature=0.7,
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise RuntimeError(f"GPT request failed: {exc}") from exc
+
+    lines = response.choices[0].message.content.strip().splitlines()
+    cleaned = [line.lstrip("0123456789.- ").strip() for line in lines if line.strip()]
+    return cleaned[:limit]
+
+
+def choose_recipe(options: List[str]) -> str:
+    """Prompt the user to select one recipe option."""
+    if not options:
+        raise ValueError("No recipe options available")
+
+    print("Recipe options:")
+    for idx, name in enumerate(options, start=1):
+        print(f"{idx}. {name}")
+
+    while True:
+        choice = input(f"Select [1-{len(options)}]: ").strip()
+        if choice.isdigit() and 1 <= int(choice) <= len(options):
+            return options[int(choice) - 1]
+        print("Invalid selection, try again.")
+
+
+def save_selection(selected: str, options: List[str]) -> None:
+    """Write the chosen recipe and list of options to files for Home Assistant."""
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    OPTIONS_FILE.write_text("\n".join(options), encoding="utf-8")
+    SELECTED_FILE.write_text(selected, encoding="utf-8")
+
+
+def main(argv: List[str] | None = None) -> None:
+    """Entry point: fetch recipes and prompt for selection."""
+    argv = argv or sys.argv[1:]
+    if not argv:
+        print("Usage: recipe_finder.py \"ingredient1, ingredient2\"")
+        raise SystemExit(1)
+
+    ingredients = argv[0]
+    try:
+        options = fetch_recipes(ingredients)
+    except Exception as exc:  # noqa: BLE001
+        sys.exit(f"Failed to fetch recipes: {exc}")
+
+    try:
+        selected = choose_recipe(options)
+    except Exception as exc:  # noqa: BLE001
+        sys.exit(f"Selection error: {exc}")
+
+    save_selection(selected, options)
+    print(f"Chosen recipe saved to {SELECTED_FILE}")
+
+
+if __name__ == "__main__":
+    main()

--- a/recipes_dashboard.yaml
+++ b/recipes_dashboard.yaml
@@ -1,0 +1,37 @@
+views:
+  - title: Recipes
+    path: recipes
+    type: panel
+    badges: []
+    cards:
+      - type: vertical-stack
+        cards:
+          - type: markdown
+            content: |
+              ## Recipe Finder
+              Enter ingredients and tap Search.
+          - type: grid
+            columns: 1
+            square: false
+            cards:
+              - type: entity
+                entity: input_text.recipe_ingredients
+                name: Ingredients
+              - type: button
+                name: Search Recipes
+                show_state: false
+                tap_action:
+                  action: call-service
+                  service: shell_command.run_recipe_finder
+              - type: markdown
+                content: |
+                  {{ states('sensor.recipe_options') }}
+              - type: markdown
+                content: |
+                  {{ states('sensor.selected_recipe') }}
+                card_mod:
+                  style: |
+                    ha-card {
+                      font-size: 2em;
+                      text-align: center;
+                    }


### PR DESCRIPTION
## Summary
- replace Edamam API usage with GPT in recipe finder
- update docs for GPT-based recipe suggestions
- remove recipe section from main dashboard and create dedicated recipes dashboard

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68466fd14854832d871e57464c8b48a4